### PR TITLE
Added hostname function to templates

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/google/uuid"
+	"os"
 	"text/template"
 	"time"
 )
@@ -17,8 +18,9 @@ func EvalTemplate(templName, templStr string, templSrc interface{}) (string, err
 	}
 
 	templ, err := template.New(templName).Funcs(template.FuncMap{
-		"UnixTime": func(i int64) time.Time { return time.Unix(i, 0) },
+		"UnixTime":      func(i int64) time.Time { return time.Unix(i, 0) },
 		"UUIDFromBytes": uuid.FromBytes,
+		"Hostname":      os.Hostname,
 	}).Parse(templStr)
 	if err != nil {
 		return "", fmt.Errorf("Error building template: %s", err)

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 	"time"
 )
@@ -13,6 +14,7 @@ var (
 	templateOk          = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} !"
 	templateOkUnixTime  = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Executed: {{(UnixTime .Check.Executed).Format \"2 Jan 2006 15:04:05\"}} !"
 	templateOkUUID      = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Event ID: {{UUIDFromBytes .ID}} !"
+	templateOkHostname  = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Hostname: {{Hostname}} !"
 	templateVarNotFound = "Check: {{ .Check.NameZZZ }} Entity: {{ .Entity.Name }} !"
 	templateInvalid     = "Check: {{ .Check.Name Entity: {{ .Entity.Name }} !"
 )
@@ -35,7 +37,7 @@ func TestEvalTemplateUnixTime_Valid(t *testing.T) {
 	executed := time.Unix(event.Check.Executed, 0).Format("2 Jan 2006 15:04:05")
 	result, err := EvalTemplate("templOk", templateOkUnixTime, event)
 	assert.Nil(t, err)
-	assert.Equal(t, "Check: check-nginx Entity: webserver01 Executed: " + executed + " !", result)
+	assert.Equal(t, "Check: check-nginx Entity: webserver01 Executed: "+executed+" !", result)
 }
 
 // Valid test - UUID
@@ -46,7 +48,18 @@ func TestEvalTemplateUUIDValid(t *testing.T) {
 	uuidFromEvent, _ := uuid.FromBytes(event.ID)
 	result, err := EvalTemplate("templOk", templateOkUUID, event)
 	assert.Nil(t, err)
-	assert.Equal(t, "Check: check-nginx Entity: webserver01 Event ID: " + uuidFromEvent.String() + " !", result)
+	assert.Equal(t, "Check: check-nginx Entity: webserver01 Event ID: "+uuidFromEvent.String()+" !", result)
+}
+
+// Valid test - Hostname
+func TestEvalTemplateHostname(t *testing.T) {
+	event := &types.Event{}
+	_ = json.Unmarshal(testEventBytes, event)
+
+	hostname, _ := os.Hostname()
+	result, err := EvalTemplate("templOk", templateOkHostname, event)
+	assert.Nil(t, err)
+	assert.Equal(t, "Check: check-nginx Entity: webserver01 Hostname: "+hostname+" !", result)
 }
 
 // Variable not found


### PR DESCRIPTION
Allow Sensu Go plugin users to use the local system's hostname in command line argument templating. For example:

```
"{{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}} - https://{{ Hostname }}:3000/c/~/n/default/events/{{.Entity.Name}}/{{.Check.Name}}"
```