### PR TITLE
add option to treat array of string arguments as StringArray

### DIFF
--- a/sensu/gocheck_test.go
+++ b/sensu/gocheck_test.go
@@ -1,6 +1,7 @@
 package sensu
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -13,11 +14,13 @@ type checkValues struct {
 	arg1 string
 	arg2 uint64
 	arg3 bool
+	arg4 []string
+	arg5 []string
 }
 
 var (
 	defaultCheckConfig = PluginConfig{
-		Name:     "TestHandler",
+		Name:     "TestCheck",
 		Short:    "Short Description",
 		Timeout:  10,
 		Keyspace: "sensu.io/plugins/segp/config",
@@ -26,6 +29,8 @@ var (
 	checkOption1 = defaultOption1
 	checkOption2 = defaultOption2
 	checkOption3 = defaultOption3
+	checkOption4 = defaultOption4
+	checkOption5 = defaultOption5
 )
 
 func TestNewGoCheck(t *testing.T) {
@@ -36,14 +41,22 @@ func TestNewGoCheck(t *testing.T) {
 	}, func(_ *types.Event) (int, error) {
 		return 0, nil
 	}, false)
+	var exitStatus = -99
+	goCheck.exitFunction = func(i int) {
+		exitStatus = i
+	}
+	goCheck.Execute()
+	fmt.Println(goCheck.cmd.Usage())
+	assert.Equal(t, 0, exitStatus)
 
 	assert.NotNil(t, goCheck)
 	assert.NotNil(t, goCheck.options)
 	assert.Equal(t, options, goCheck.options)
 	assert.NotNil(t, goCheck.config)
-	assert.Equal(t, &defaultHandlerConfig, goCheck.config)
+	assert.Equal(t, &defaultCheckConfig, goCheck.config)
 	assert.NotNil(t, goCheck.validationFunction)
 	assert.NotNil(t, goCheck.executeFunction)
+	assert.NotNil(t, goCheck.cmd)
 	assert.Nil(t, goCheck.sensuEvent)
 	assert.Equal(t, os.Stdin, goCheck.eventReader)
 }
@@ -52,14 +65,20 @@ func getCheckOptions(values *checkValues) []*PluginConfigOption {
 	option1 := checkOption1
 	option2 := checkOption2
 	option3 := checkOption3
+	option4 := checkOption4
+	option5 := checkOption5
 	if values != nil {
 		option1.Value = &values.arg1
 		option2.Value = &values.arg2
 		option3.Value = &values.arg3
+		option4.Value = &values.arg4
+		option5.Value = &values.arg5
 	} else {
 		option1.Value = nil
 		option2.Value = nil
 		option3.Value = nil
+		option4.Value = nil
+		option5.Value = nil
 	}
-	return []*PluginConfigOption{&option1, &option2, &option3}
+	return []*PluginConfigOption{&option1, &option2, &option3, &option4, &option5}
 }

--- a/sensu/gocheck_test.go
+++ b/sensu/gocheck_test.go
@@ -1,7 +1,6 @@
 package sensu
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -46,7 +45,6 @@ func TestNewGoCheck(t *testing.T) {
 		exitStatus = i
 	}
 	goCheck.Execute()
-	fmt.Println(goCheck.cmd.Usage())
 	assert.Equal(t, 0, exitStatus)
 
 	assert.NotNil(t, goCheck)

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -154,6 +154,7 @@ func goHandlerExecuteUtil(t *testing.T, handlerConfig *PluginConfig, eventFile s
 		errorStr = fmt.Sprintf(format, a...)
 	}
 	goHandler.Execute()
+	fmt.Println(values.arg4, len(values.arg4))
 	assert.Equal(t, expectedValue1, values.arg1)
 	assert.Equal(t, expectedValue2, values.arg2)
 	assert.Equal(t, expectedValue3, values.arg3)
@@ -252,8 +253,8 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 	_ = os.Setenv("ENV_1", "value-env1")
 	_ = os.Setenv("ENV_2", "9753")
 	_ = os.Setenv("ENV_3", "true")
-	_ = os.Setenv("ENV_4", "this,is,an,env,var")
-	_ = os.Setenv("ENV_5", "this,is,an,env,var")
+	_ = os.Setenv("ENV_4", "this, is, an, env, var ")
+	_ = os.Setenv("ENV_5", "this, is, an, env, var")
 	exitStatus, _ := goHandlerExecuteUtil(t, &defaultHandlerConfig, "test/event-no-override.json", nil,
 		func(event *types.Event) error {
 			validateCalled = true
@@ -264,7 +265,7 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-env1", uint64(9753), true, 1, 0)
+		"value-env1", uint64(9753), true, 5, 0)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -177,7 +177,7 @@ func TestGoHandler_Execute_Check(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-check1", uint64(1357), false, 2, 1)
+		"value-check1", uint64(1357), false, 2, 2)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -154,7 +154,6 @@ func goHandlerExecuteUtil(t *testing.T, handlerConfig *PluginConfig, eventFile s
 		errorStr = fmt.Sprintf(format, a...)
 	}
 	goHandler.Execute()
-	fmt.Println(values.arg4, len(values.arg4))
 	assert.Equal(t, expectedValue1, values.arg1)
 	assert.Equal(t, expectedValue2, values.arg2)
 	assert.Equal(t, expectedValue3, values.arg3)
@@ -253,8 +252,8 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 	_ = os.Setenv("ENV_1", "value-env1")
 	_ = os.Setenv("ENV_2", "9753")
 	_ = os.Setenv("ENV_3", "true")
-	_ = os.Setenv("ENV_4", "this, is, an, env, var ")
-	_ = os.Setenv("ENV_5", "this, is, an, env, var")
+	_ = os.Setenv("ENV_4", "this is a space delimited string slice")
+	_ = os.Setenv("ENV_5", "this is a single string entry in string array")
 	exitStatus, _ := goHandlerExecuteUtil(t, &defaultHandlerConfig, "test/event-no-override.json", nil,
 		func(event *types.Event) error {
 			validateCalled = true
@@ -265,7 +264,7 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-env1", uint64(9753), true, 5, 0)
+		"value-env1", uint64(9753), true, 7, 1)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -177,7 +177,7 @@ func TestGoHandler_Execute_Check(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-check1", uint64(1357), false, 1, 1)
+		"value-check1", uint64(1357), false, 2, 1)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -177,7 +177,7 @@ func TestGoHandler_Execute_Check(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-check1", uint64(1357), false, 0, 0)
+		"value-check1", uint64(1357), false, 1, 1)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)
@@ -252,6 +252,8 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 	_ = os.Setenv("ENV_1", "value-env1")
 	_ = os.Setenv("ENV_2", "9753")
 	_ = os.Setenv("ENV_3", "true")
+	_ = os.Setenv("ENV_4", "this,is,an,env,var")
+	_ = os.Setenv("ENV_5", "this,is,an,env,var")
 	exitStatus, _ := goHandlerExecuteUtil(t, &defaultHandlerConfig, "test/event-no-override.json", nil,
 		func(event *types.Event) error {
 			validateCalled = true
@@ -262,7 +264,7 @@ func TestGoHandler_Execute_Environment(t *testing.T) {
 			assert.NotNil(t, event)
 			return nil
 		},
-		"value-env1", uint64(9753), true, 0, 0)
+		"value-env1", uint64(9753), true, 1, 0)
 	assert.Equal(t, 0, exitStatus)
 	assert.True(t, validateCalled)
 	assert.True(t, executeCalled)

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -203,7 +203,12 @@ func setupFlag(cmd *cobra.Command, opt *PluginConfigOption) error {
 			return fmt.Errorf("only pointer to []string is allowed, not %v", kind)
 		}
 		if opt.Array {
-			cmd.Flags().StringArrayVarP(ptr, opt.Argument, opt.Shorthand, opt.Default.([]string), opt.Usage)
+			val := viper.GetString(opt.Argument)
+			strSlice := []string{}
+			if len(val) > 0 {
+				strSlice = append(strSlice, val)
+			}
+			cmd.Flags().StringArrayVarP(ptr, opt.Argument, opt.Shorthand, strSlice, opt.Usage)
 		} else {
 			cmd.Flags().StringSliceVarP(ptr, opt.Argument, opt.Shorthand, viper.GetStringSlice(opt.Argument), opt.Usage)
 		}

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -54,6 +54,9 @@ type PluginConfigOption struct {
 
 	// If secret option do not copy Argument value into Default
 	Secret bool
+
+	// If array option set, treat StringSlice as StringArray, do not automatically parse as CSV comma delimited
+	Array bool
 }
 
 // PluginConfig defines the base plugin configuration.
@@ -199,7 +202,11 @@ func setupFlag(cmd *cobra.Command, opt *PluginConfigOption) error {
 		if !ok {
 			return fmt.Errorf("only pointer to []string is allowed, not %v", kind)
 		}
-		cmd.Flags().StringSliceVarP(ptr, opt.Argument, opt.Shorthand, viper.GetStringSlice(opt.Argument), opt.Usage)
+		if opt.Array {
+			cmd.Flags().StringArrayVarP(ptr, opt.Argument, opt.Shorthand, opt.Default.([]string), opt.Usage)
+		} else {
+			cmd.Flags().StringSliceVarP(ptr, opt.Argument, opt.Shorthand, viper.GetStringSlice(opt.Argument), opt.Usage)
+		}
 	case reflect.String:
 		cmd.Flags().StringVarP(opt.Value.(*string), opt.Argument, opt.Shorthand, viper.GetString(opt.Argument), opt.Usage)
 	default:

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -55,7 +55,7 @@ type PluginConfigOption struct {
 	// If secret option do not copy Argument value into Default
 	Secret bool
 
-	// If array option set, treat StringSlice as StringArray, do not automatically parse as CSV comma delimited
+	// If array option set, treat StringSlice as StringArray, do not automatically parse as CSV space delimited
 	Array bool
 }
 

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -203,8 +203,11 @@ func setupFlag(cmd *cobra.Command, opt *PluginConfigOption) error {
 			return fmt.Errorf("only pointer to []string is allowed, not %v", kind)
 		}
 		if opt.Array {
+			// Treat this as a StringArrayVar do not automatically parse string as space delimited list
+			// Grab the fallback envvar value as string via viper
 			val := viper.GetString(opt.Argument)
 			strSlice := []string{}
+			// If the fallback value is non-empty, append it as first string in array
 			if len(val) > 0 {
 				strSlice = append(strSlice, val)
 			}

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -44,7 +44,7 @@ func TestSetOptionValue_EmptySlice(t *testing.T) {
 	assert.Equal(t, []string{""}, finalValue)
 }
 
-func TestSetOptionValue_SliceType(t *testing.T) {
+func TestSetOptionValue_StringSliceType(t *testing.T) {
 	type stringSlice []string
 	finalValue := stringSlice{"def"}
 	option := defaultOption1
@@ -54,10 +54,31 @@ func TestSetOptionValue_SliceType(t *testing.T) {
 	assert.Equal(t, stringSlice{"abc"}, finalValue)
 }
 
-func TestSetOptionValue_JSONArray(t *testing.T) {
+func TestSetOptionValue_StringArrayType(t *testing.T) {
+	type stringArray []string
+	finalValue := stringArray{"def"}
+	option := defaultOption1
+	option.Value = &finalValue
+	option.Array = true
+	err := setOptionValue(&option, "abc")
+	assert.Nil(t, err)
+	assert.Equal(t, stringArray{"abc"}, finalValue)
+}
+
+func TestSetOptionValue_JSONArrayStringSlice(t *testing.T) {
 	var finalValue []string
 	option := defaultOption1
 	option.Value = &finalValue
+	err := setOptionValue(&option, `["abc","def"]`)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"abc", "def"}, finalValue)
+}
+
+func TestSetOptionValue_JSONArrayStringArray(t *testing.T) {
+	var finalValue []string
+	option := defaultOption1
+	option.Value = &finalValue
+	option.Array = true
 	err := setOptionValue(&option, `["abc","def"]`)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"abc", "def"}, finalValue)
@@ -125,4 +146,6 @@ func clearEnvironment() {
 	_ = os.Unsetenv("ENV_1")
 	_ = os.Unsetenv("ENV_2")
 	_ = os.Unsetenv("ENV_3")
+	_ = os.Unsetenv("ENV_4")
+	_ = os.Unsetenv("ENV_5")
 }

--- a/sensu/test/event-check-override.json
+++ b/sensu/test/event-check-override.json
@@ -108,8 +108,8 @@
         "sensu.io/plugins/segp/config/path1": "value-check1",
         "sensu.io/plugins/segp/config/path2": "1357",
         "sensu.io/plugins/segp/config/path3": "false",
-        "sensu.io/plugins/segp/config/path4": "[ \"arg4\", \"as escaped escaped json string array of strings\" ]" ,
-        "sensu.io/plugins/segp/config/path5": "[ \"arg5\", \"as escaped escaped json string array of strings\" ]" 
+        "sensu.io/plugins/segp/config/path4": "[ \"arg4\", \"as json string array of escaped strings\" ]" ,
+        "sensu.io/plugins/segp/config/path5": "[ \"arg5\", \"as json string array of escaped strings\" ]" 
       }
     }
   }

--- a/sensu/test/event-check-override.json
+++ b/sensu/test/event-check-override.json
@@ -109,7 +109,7 @@
         "sensu.io/plugins/segp/config/path2": "1357",
         "sensu.io/plugins/segp/config/path3": "false",
         "sensu.io/plugins/segp/config/path4": "[ \"arg4\", \"as escaped escaped json string array of strings\" ]" ,
-        "sensu.io/plugins/segp/config/path5": "arg5 string array override is treated as single string"
+        "sensu.io/plugins/segp/config/path5": "[ \"arg5\", \"as escaped escaped json string array of strings\" ]" 
       }
     }
   }

--- a/sensu/test/event-check-override.json
+++ b/sensu/test/event-check-override.json
@@ -108,7 +108,7 @@
         "sensu.io/plugins/segp/config/path1": "value-check1",
         "sensu.io/plugins/segp/config/path2": "1357",
         "sensu.io/plugins/segp/config/path3": "false",
-        "sensu.io/plugins/segp/config/path4": "arg4 string slice override is treated as single string, unlike argument and env",
+        "sensu.io/plugins/segp/config/path4": "[ \"arg4\", \"as escaped escaped json string array of strings\" ]" ,
         "sensu.io/plugins/segp/config/path5": "arg5 string array override is treated as single string"
       }
     }

--- a/sensu/test/event-check-override.json
+++ b/sensu/test/event-check-override.json
@@ -107,7 +107,9 @@
       "annotations": {
         "sensu.io/plugins/segp/config/path1": "value-check1",
         "sensu.io/plugins/segp/config/path2": "1357",
-        "sensu.io/plugins/segp/config/path3": "false"
+        "sensu.io/plugins/segp/config/path3": "false",
+        "sensu.io/plugins/segp/config/path4": "this,is,an,override",
+        "sensu.io/plugins/segp/config/path5": "this,is,an,override"
       }
     }
   }

--- a/sensu/test/event-check-override.json
+++ b/sensu/test/event-check-override.json
@@ -108,8 +108,8 @@
         "sensu.io/plugins/segp/config/path1": "value-check1",
         "sensu.io/plugins/segp/config/path2": "1357",
         "sensu.io/plugins/segp/config/path3": "false",
-        "sensu.io/plugins/segp/config/path4": "this,is,an,override",
-        "sensu.io/plugins/segp/config/path5": "this,is,an,override"
+        "sensu.io/plugins/segp/config/path4": "arg4 string slice override is treated as single string, unlike argument and env",
+        "sensu.io/plugins/segp/config/path5": "arg5 string array override is treated as single string"
       }
     }
   }


### PR DESCRIPTION
Closes #54 

Implements an optional attribute Array, that if set changes how multiple call argument stringSlice are processed.
StringSlice  -> automatic CSV comma delimited spliting of string value of each call of the argument
StringArray -> no automatic spliting of argument values, each argument call is taken as a separate array entry.

This is implemented as optional, because StringArray use requires more work when using with envvar to ensure you can split the envvar string using an delimiting string of your choice after arguments are parsed, but when strings need to have commas this gives you a way to deal with that.

gohandler_test.go  updated with unit tests for both stringSlice and StringArray argument,envvar and annotation override handling.

Note we already have inconsistent handling of annotation overrides relative to argument and envvar handling for existing StringSlice Ref: #56.  