### PR TITLE
Don't display usage when biz logic fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- CLI usage is no longer displayed when business logic execution fails.
+
 ## [0.14.0] - 2021-08-09
 ### Added
 - Added new aws sub-package to facilite aws service plugin development

--- a/sensu/gocheck.go
+++ b/sensu/gocheck.go
@@ -53,7 +53,7 @@ func (goCheck *GoCheck) goCheckWorkflow(_ []string) (int, error) {
 	// Validate input using validateFunction
 	status, err := goCheck.validationFunction(goCheck.sensuEvent)
 	if err != nil {
-		return status, fmt.Errorf("error validating input: %s", err)
+		return status, ErrValidationFailed(err.Error())
 	}
 
 	// Execute check logic using executeFunction

--- a/sensu/gohandler.go
+++ b/sensu/gohandler.go
@@ -93,7 +93,7 @@ func (goHandler *GoHandler) goHandlerWorkflow(_ []string) (int, error) {
 	// Validate input using validateFunction
 	err := goHandler.validationFunction(event)
 	if err != nil {
-		return 1, fmt.Errorf("error validating input: %s", err)
+		return 1, ErrValidationFailed(err.Error())
 	}
 
 	// Execute handler logic using executeFunction

--- a/sensu/gomutator.go
+++ b/sensu/gomutator.go
@@ -50,7 +50,7 @@ func (goMutator *GoMutator) goMutatorWorkflow(_ []string) (int, error) {
 	// Validate input using validateFunction
 	err := goMutator.validationFunction(goMutator.sensuEvent)
 	if err != nil {
-		return 1, fmt.Errorf("error validating input: %s", err)
+		return 1, ErrValidationFailed(err.Error())
 	}
 
 	// Execute handler logic using executeFunction

--- a/sensu/validation.go
+++ b/sensu/validation.go
@@ -1,0 +1,9 @@
+package sensu
+
+// ErrValidationFailed should be returned when a configuration validation
+// function fails.
+type ErrValidationFailed string
+
+func (e ErrValidationFailed) Error() string {
+	return string(e)
+}


### PR DESCRIPTION
This commit fixes a bug where usage information is displayed when
business logic execution fails.

Closes #57 