### PR TITLE
enable []string as option value

### DIFF
--- a/sensu/plugin.go
+++ b/sensu/plugin.go
@@ -40,7 +40,7 @@ type ConfigOption interface {
 // OptionValue is a type constraint that creates a compile-time guard against
 // creating a PluginConfigOption with an unsupported data type.
 type OptionValue interface {
-	~int | ~int32 | ~int64 | ~uint | ~uint32 | ~uint64 | ~float32 | ~float64 | ~bool | ~string
+	~int | ~int32 | ~int64 | ~uint | ~uint32 | ~uint64 | ~float32 | ~float64 | ~bool | ~string | ~[]string
 }
 
 // SliceOptionValue is like OptionValue but applies to SlicePluginConfigOption.


### PR DESCRIPTION
Have been trying to update [sensu/http-checks]( https://github.com/sensu/http-checks) but it has a `--headers` CLI argument that uses `[]string` as data type. ([WIP for http-check](https://github.com/elfranne/http-checks/tree/corev2))

The [test code](https://github.com/sensu/sensu-plugin-sdk/blob/22b986c98a7523e60bd768b32e181de35ecd7c4c/sensu/handler_test.go#L61C2-L61C17) was already present.
